### PR TITLE
fix: typo on env value

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ curl -X POST \
     --data "{\"name\":\"$KVM_NAME1\",\"encrypted\": true}"
 
 curl -X POST \
-    "https://apigee.googleapis.com/v1/organizations/${APIGEE_ORG}/environments/c/keyvaluemaps" \
+    "https://apigee.googleapis.com/v1/organizations/${APIGEE_ORG}/environments/$APIGEE_ENV/keyvaluemaps" \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     --data "{\"name\":\"$KVM_NAME2\",\"encrypted\": true}"


### PR DESCRIPTION
Minor typo fix, following discussion on [GoogleCloud Community](https://www.googlecloudcommunity.com/gc/Apigee/Apigee-X-and-KVM-weird-API-behaviour/m-p/452592)